### PR TITLE
Update backend

### DIFF
--- a/backend/controllers/controllers.go
+++ b/backend/controllers/controllers.go
@@ -6,10 +6,14 @@ import (
 	"backend/util"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
+	"os/exec"
+	"path"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
@@ -172,24 +176,12 @@ func AuthHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(user)
 }
 
-// Nutrition endpoint. Accepts a fruit name and makes a call to CalorieNinjas API to retrieve and serve food nutrition info
-func NutritionHandler(w http.ResponseWriter, r *http.Request) {
-
-	// Declare a new Fruit struct to hold response from client
-	var fruit models.Fruit
-
-	// Try to decode the request body into the Fruit struct. If there is an error,
-	// respond to the client with the error message and a 400 status code.
-	err := json.NewDecoder(r.Body).Decode(&fruit)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
+// Retrieves nutritional info of a fruit from CalorieNinja
+func getNutritionalInfo(fruitName string) models.FruitNutrition {
 	// API endpoint of CalorieNinja + fruit name parameter passed by the client
-	endpoint := "https://api.calorieninjas.com/v1/nutrition?query=" + fruit.Name
+	endpoint := "https://api.calorieninjas.com/v1/nutrition?query=" + fruitName
 
-	// Make API call to CalorieNinja API
+	// Make a http call to CalorieNinja API
 	client := &http.Client{}
 	req, _ := http.NewRequest("GET", endpoint, nil)
 	// Pass API key in header. The API key is an environment variable set in the .env file
@@ -199,14 +191,101 @@ func NutritionHandler(w http.ResponseWriter, r *http.Request) {
 	defer resp.Body.Close()
 
 	// Response payload
-	var payload map[string]interface{}
+	// var payload map[string]interface{}
+	fruitNutrition := models.FruitNutrition{}
 
-	// Decode body response from the API call and decode into payload
-	json.NewDecoder(resp.Body).Decode(&payload)
+	// Decode JSON response from the API call and decode into payload struct
+	json.NewDecoder(resp.Body).Decode(&fruitNutrition)
+	return fruitNutrition
+}
 
-	// Respond in JSON
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+// SearchHandler accepts an input image, predicts the type of fruit then returns fruit nutritional info
+func SearchHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Println("File Upload Endpoint Hit")
 
-	json.NewEncoder(w).Encode(payload)
+	// Parse our multipart form, 10 << 20 specifies a maximum
+	// upload of 10 MB files.
+	r.ParseMultipartForm(10 << 20)
+
+	// FormFile returns the first file for the given key `image`
+	// it also returns the FileHeader so we can get the Filename,
+	// the Header and the size of the file
+	file, handler, err := r.FormFile("image")
+	if err != nil {
+		fmt.Println("Error Retrieving the File")
+		fmt.Println(err)
+		return
+	}
+	defer file.Close()
+	fmt.Printf("Uploaded File: %+v\n", handler.Filename)
+	// fmt.Printf("File Size: %+v\n", handler.Size)
+	// fmt.Printf("MIME Header: %+v\n", handler.Header)
+
+	// Create a temporary file within our temp-images directory that follows
+	// a particular naming pattern
+	tempFile, err := ioutil.TempFile("temp-images", "upload-*.png")
+	if err != nil {
+		fmt.Println(err)
+	}
+	defer tempFile.Close()
+
+	// read all of the contents of our uploaded file into a
+	// byte array
+	fileBytes, err := ioutil.ReadAll(file)
+	if err != nil {
+		fmt.Println(err)
+	}
+	// write this byte array to our temporary file
+	tempFile.Write(fileBytes)
+	// return that we have successfully uploaded our file!
+
+	// Dodgy way to execute Python script from Go (but it works!)
+	// Update according to your environment
+	python := path.Clean(strings.Join([]string{"C:\\", "Users", "Marck", "AppData", "Local", "Programs", "Python", "Python310", "python.exe"}, "\\"))
+	script := path.Clean(strings.Join([]string{"C:\\", "Users", "Marck", "Desktop", "team-12-project", "machine_learning", "predict.py"}, "\\"))
+	img_path := "\\" + tempFile.Name()
+
+	// executes the python script using CMD and passes the path of uploaded image
+	cmd := exec.Command(python, script, img_path)
+	out, err := cmd.Output()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// predicted fruit name from python script. 
+	predictionStr := strings.Trim(string(out), "\r\n") // trim "\r\n" from string
+
+	// get nutritional info from CalorieNinja based on predicted fruit name
+	fruitNutritionInfo := getNutritionalInfo(predictionStr)
+
+	// The model will always output a prediction but the predicted fruit may not exist in CalorieNinja
+	// if this is the case, just return the name of the predicted fruit with a message.
+	if len(fruitNutritionInfo.Items) == 0 {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+
+		json.NewEncoder(w).Encode(map[string]string{"name:": predictionStr, "msg:": "Unable to find nutritional info."})
+
+	} else {
+		payload := models.Fruit{
+			Name: predictionStr,
+			Calories: 	fruitNutritionInfo.Items[0].Calories,
+			Carbs: 		fruitNutritionInfo.Items[0].Carbs,
+			Chols: 		fruitNutritionInfo.Items[0].Chols,
+			FatSat: 	fruitNutritionInfo.Items[0].FatSat,
+			FatTotal: 	fruitNutritionInfo.Items[0].FatTotal,
+			Fiber: 		fruitNutritionInfo.Items[0].Fiber,
+			Potassium: 	fruitNutritionInfo.Items[0].Potassium,
+			Protein: 	fruitNutritionInfo.Items[0].Protein,
+			Serving: 	fruitNutritionInfo.Items[0].Serving,
+			Sodium: 	fruitNutritionInfo.Items[0].Sodium,
+			Sugar: 		fruitNutritionInfo.Items[0].Sugar,
+		}
+
+		// Respond in JSON
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+
+		json.NewEncoder(w).Encode(payload)
+	}
 }

--- a/backend/models/models.go
+++ b/backend/models/models.go
@@ -4,7 +4,36 @@ package models
 
 // Fruit struct
 type Fruit struct {
-	Name string `json:"name"`
+	Name 		string `json:"name"`
+	Calories 	float32 `json:"calories"`
+	Carbs 		float32 `json:"carbohydrates_total_g"`
+	Chols 		float32 `json:"cholesterol_mg"`
+	FatSat 		float32 `json:"fat_saturated_g"`
+	FatTotal 	float32 `json:"fat_total_g"`
+	Fiber 		float32 `json:"fiber_g"`
+	Potassium 	float32 `json:"potassium_mg"`
+	Protein 	float32 `json:"protein_g"`
+	Serving		float32 `json:"serving_size_g"`
+	Sodium 		float32 `json:"sodium_mg"`
+	Sugar 		float32 `json:"sugar_g"`
+}
+
+// Struct for fruit nutrition info
+type FruitNutrition struct {
+	Items	[]struct {
+		Calories 	float32 `json:"calories"`
+		Carbs 		float32 `json:"carbohydrates_total_g"`
+		Chols 		float32 `json:"cholesterol_mg"`
+		FatSat 		float32 `json:"fat_saturated_g"`
+		FatTotal 	float32 `json:"fat_total_g"`
+		Fiber 		float32 `json:"fiber_g"`
+		Name 		string `json:"name"`
+		Potassium 	float32 `json:"potassium_mg"`
+		Protein 	float32 `json:"protein_g"`
+		Serving 	float32 `json:"serving_size_g"`
+		Sodium 		float32 `json:"sodium_mg"`
+		Sugar 		float32 `json:"sugar_g"`
+	}
 }
 
 // User model

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -11,5 +11,5 @@ func SetRoutes(r *mux.Router) {
 	r.HandleFunc("/ping", controllers.PingHandler).Methods("GET")
 	r.HandleFunc("/register", controllers.RegisterHandler).Methods("POST")
 	r.HandleFunc("/authenticate", controllers.AuthHandler).Methods("POST")
-	r.HandleFunc("/nutrition", controllers.NutritionHandler).Methods("POST")
+	r.HandleFunc("/search", controllers.SearchHandler).Methods("POST")
 }

--- a/machine_learning/predict.py
+++ b/machine_learning/predict.py
@@ -1,30 +1,40 @@
 import os
+import sys
 import numpy as np
+
 from tensorflow import keras
-from tensorflow.keras.preprocessing.image import load_img, img_to_array
+# Supress warning logs from tensorflow. Use version 2.8.0
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+#from tensorflow.keras.preprocessing.image import img_to_array, load_img
+
+# In the current implementation and for Golang to execute this script
+# prefix to the machine learning and backend folder are required.
+FILENAME_PREFIX = "C:\\Users\\Marck\\Desktop\\team-12-project\\machine_learning"
+IMG_FILENAME_PREFIX = "C:\\Users\\Marck\\Desktop\\team-12-project\\backend"
 
 # Get fruit categories based on training dir subdirectories
 def get_categories():
 	# Training dataset dir
-	train_dir = "fruits_dataset/train"
+	train_dir = FILENAME_PREFIX+"/fruits_dataset/train"
 	Name=[]
 	for file in os.listdir(train_dir):
 		Name+=[file]
 	# Create map    
-	fruit_map = dict(zip(Name, [t for t in range(len(Name))]))
-	# print(fruit_map)
+	#fruit_map = dict(zip(Name, [t for t in range(len(Name))]))
+	#print(fruit_map)
 	r_fruit_map = dict(zip([t for t in range(len(Name))],Name))
 	return r_fruit_map
 	
 # Mapper function
 def category_mapper(value):
-    return r_fruit_map[value]
+	global r_fruit_map
+	return r_fruit_map[value]
 
 # Load image and convert size	
 def load_image(image_path):
-	image=load_img(image_path,target_size=(100,100))
+	image=keras.preprocessing.image.load_img(image_path,target_size=(100,100))
 
-	image=img_to_array(image) 
+	image=keras.preprocessing.image.img_to_array(image) 
 	image=image/255.0
 	prediction_image=np.array(image)
 	prediction_image= np.expand_dims(image, axis=0)
@@ -36,16 +46,19 @@ def predict(prediction_image):
 	prediction = model.predict(prediction_image)
 	value = np.argmax(prediction)
 	move_name = category_mapper(value)
-	print("Prediction is {}.".format(move_name))
+	return move_name
+
 
 # Load trained model
-model = keras.models.load_model('fruit_model.h5')
+model = keras.models.load_model(FILENAME_PREFIX+'/fruit_model.h5')
 
 r_fruit_map = get_categories()
 
-test_image = 'fruits_dataset/test/0030.jpg'
-prediction_image = load_image(test_image)
+# test_image = 'fruits_dataset/test/0030.jpg'
+# The uploaded image's location is passed as an argument to this script.
+img_path = IMG_FILENAME_PREFIX+sys.argv[1]
 
-predict(prediction_image)
+prediction_image = load_image(img_path)
 
-
+# Print predicted fruit name to console which is then used by Golang.
+print(predict(prediction_image))


### PR DESCRIPTION
WHAT:

- Merging @Cam-ak 's implementation to call python script
- Removed /nutrition endpoint as it's no longer required. The /search endpoint now predicts the fruit and then calls the calorie ninja API at the same time and responds with the following format:

```
{
    "name": "Watermelon",
    "calories": 30.3,
    "carbohydrates_total_g": 7.4,
    "cholesterol_mg": 0,
    "fat_saturated_g": 0,
    "fat_total_g": 0.1,
    "fiber_g": 0.4,
    "potassium_mg": 10,
    "protein_g": 0.6,
    "serving_size_g": 100,
    "sodium_mg": 0,
    "sugar_g": 6.2
}
```

If the predicted fruit cannot be found in calorie ninja API, it outputs the fruit name and a message:

```
{
    "msg:": "Unable to find nutritional info.",
    "name:": "Apple Granny Smith"
}
```